### PR TITLE
Rename "stable" to "release"

### DIFF
--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -12,7 +12,7 @@
     </a>
     @endforeach
     <a href="/downloads/master/latest" class="fright stable">
-        <div>Download {{ $stable->version }} stable</div>
+        <div>Download {{ $stable->version }} release</div>
         <small>{{ $stable->version ."-". $stable->gitBranch ."-". $stable->gitHashShort }} ({{ Carbon::createFromTimeStamp(strtotime($stable->addedTime))->diffForHumans() }})</small>
     </a>
 </div>


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/commit/f54e73061ac2e77055e69617b709932c55aeb913

We don't want to call it "stable", it implies it has been tested and is
of known, good quality, which we do not know. More often than not,
the `develop` builds are more stable than `master`. We should call
them just "release" instead.