### PR TITLE
Stop using G2A

### DIFF
--- a/resources/views/download-demo.blade.php
+++ b/resources/views/download-demo.blade.php
@@ -12,7 +12,7 @@
 <h1>RollerCoaster Tycoon 2 TTP Demo</h1>
 <p>The RollerCoaster Tycoon 2 TTP Demo allows you to play the full game for 1 hour. Fortunately, OpenRCT2 removes this 1 hour time limit. By removing this limit you can enjoy the full OpenRCT2 experience without buying the game.</p>
 <h2 class="red">Warning</h2>
-<p>We highly recommend you to <a href="https://www.g2a.com/r/openrct2" target="_blank">buy the game</a> in order to support Chris Sawyer and Atari. It's really not that expensive, and gives you the full experience as it should be. Using this demo is at your own risk!</p>
+<p>We highly recommend you to <a href="http://www.gog.com/game/rollercoaster_tycoon_2" target="_blank">buy the game</a> in order to support Chris Sawyer and Atari. It's really not that expensive, and gives you the full experience as it should be. Using this demo is at your own risk!</p>
 <h2>Instructions</h2>
 <ul>
     <li>Download and install the <a href="/downloads">latest OpenRCT2 build</a>. Don't run the game yet.</li>

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -66,7 +66,6 @@
     <h2 class="orange">Original Game Required</h2>
     <p>Original RollerCoaster Tycoon 2 game files are required in order to play
         OpenRCT2. RCT2, with expansions, is cheap nowadays and can be bought from
-        <a href="https://www.g2a.com/r/openrct2" target="_blank">G2A</a>,
         <a href="http://www.gog.com/game/rollercoaster_tycoon_2" target="_blank">GOG</a>
         and <a href="http://store.steampowered.com/app/285330/" target="_blank">Steam</a>.
     </p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -15,7 +15,7 @@
 </p>
 <p>
     An installation of RollerCoaster Tycoon 2 is required in order to play.
-    RCT2, with expansions, is cheap nowadays and can be bought from <a href="//www.g2a.com/r/openrct2" target="_blank">G2A</a>, <a href="//www.gog.com/game/rollercoaster_tycoon_2" target="_blank">GOG</a> and <a href="http://store.steampowered.com/app/285330/" target="_blank">Steam</a>.
+    RCT2, with expansions, is cheap nowadays and can be bought from <a href="//www.gog.com/game/rollercoaster_tycoon_2" target="_blank">GOG</a> and <a href="http://store.steampowered.com/app/285330/" target="_blank">Steam</a>.
 </p>
 <h2 class="blue">Download and Play</h2>
 <p>


### PR DESCRIPTION
https://www.reddit.com/r/pcgaming/comments/5r0b9t/openrct2_006_released/
highlighted multiple times G2A is a shady service and should not be
considered a means to support original developers.